### PR TITLE
FileManager Patch 9.1.0

### DIFF
--- a/src/data/FileError.java
+++ b/src/data/FileError.java
@@ -1,10 +1,10 @@
 package data;
 
 public enum FileError {
-    FAILED_SAVE("| The save is not completed |"),
-    FAILED_LOAD_ER("| Loading savefile is not completed |"),
+    FAILED_SAVE("| Failed to save the game. |"),
+    FAILED_LOAD_ER("| Failed to load the savefile. |"),
     FAILED_LOAD("| The save %d is empty |"),
-    FAILED_DELETE("| Deleting savefile is not completed |"),
+    FAILED_DELETE("| Failed to delete the save file |"),
     FAILED_MAKDIR("| Failed to make a directory. |"),
     FAILED_MAKDIR_ERROR("| Unable to create save directory. The program will terminate. |"),
 

--- a/src/fileManager/FileManager.java
+++ b/src/fileManager/FileManager.java
@@ -57,8 +57,8 @@ public class FileManager {
         if (!dir.exists()) {
             boolean success = dir.mkdirs();
             if (!success) {
-                System.err.println(FileError.FAILED_MAKDIR + SAVE_DIR); //임시 출력본
-                throw new IllegalStateException(String.valueOf(FileError.FAILED_MAKDIR_ERROR));
+                //System.err.println(FileError.FAILED_MAKDIR + SAVE_DIR); //임시 출력본
+                throw new IllegalStateException();
             }
         }
     }
@@ -133,14 +133,14 @@ public class FileManager {
 
             return true;
         } catch (IOException e) {
-            System.out.println(FileError.DEBUG_ERROR_OVERWRITE); //디버깅용
+            //System.out.println(FileError.DEBUG_ERROR_OVERWRITE); //디버깅용
             return false;
         }
     }
 
     // 세이브 파일 불러오기
     public int loadSavedFile(int slot, Board targetBoard) {
-        if (slot < 1 || slot > MAX_SAVES ) return 0;
+        if (slot < 1 || slot > MAX_SAVES ) return -1;
 
         String filePath = getFilePath(slot);
 
@@ -149,13 +149,13 @@ public class FileManager {
             reader.readLine(); // 공백 줄
             String getLine = reader.readLine(); // 턴 정보 읽기
 
-            if (getLine == null) return -1;
+            if (getLine == null) return 0;
 
             //턴 정보 읽기(WHITE ? BLACK)
             if (getLine.equalsIgnoreCase("BLACK")) {
                 targetBoard.turnChange();
             } else if (!getLine.equalsIgnoreCase("WHITE")) {
-                throw new IllegalArgumentException("Invalid save file: " + getLine);
+                throw new IllegalArgumentException();
             }
 
             //보드 정보 읽기(8*8)
@@ -181,7 +181,6 @@ public class FileManager {
                 String[] parts = specialLine.split(" ");
                 if (parts.length != 3) continue; // 잘못된 형식은 무시
 
-                String symbol = parts[0];
                 int row = Integer.parseInt(parts[1]);
                 int col = Integer.parseInt(parts[2]);
 
@@ -202,8 +201,11 @@ public class FileManager {
             }
 
             return 1;
+        } catch (FileNotFoundException e) {
+            // 파일이 아예 없음
+            return 0;
         } catch (IOException | IllegalArgumentException e) {
-            System.out.println(FileError.DEBUG_ERROR_LOAD); //디버깅용
+            //System.out.println(FileError.DEBUG_ERROR_LOAD);
             return -1;
         }
     }
@@ -286,7 +288,7 @@ public class FileManager {
                     filename.set(i - 1, saveName);
                 }
             } catch (IOException e) {
-                System.out.println(FileError.DEBUG_ERROR_LOAD_FN); //디버깅용
+                //System.out.println(FileError.DEBUG_ERROR_LOAD_FN); //디버깅용
                 //e.printStackTrace(); //디버깅용 후에 주석처리
                 //손상된 파일이나 존재하지 않는 파일이나 똑같이 리스트에는 안들어옵니다.
             }


### PR DESCRIPTION
1. FileError 기획서에 맞게 수정(이전 수정은 노션본 기준이었고, 원래대로 복구)
2. FileManager return값 세분화 및 기획 의도에 맞게 변경 3-1. 1번 항목에 따른 FilePrintTests 수정
3-2. 2번 항목에 FilePrintTests 테스트 2개 추가
4. FileManager에 디버깅 용으로 있던 System.println 구문 전부 주석처리(시스템에 직접적으로 출력하는 모든 구문 주석처리)
5. 기타 코드 정리